### PR TITLE
Allow data transformation of SD_TAG values

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ SQLITE_TMPDIR=/my/large/disk/temp python /path/to/local_pubchem_db/build_pubchem
 ```
 ## Version History
 
+#### 0.3:
+- Add support for data-transformations of SDFTags
+
 #### 0.2:
 - Add flexibility for the DB-layout using a json-file
 - Add tests

--- a/README.md
+++ b/README.md
@@ -35,17 +35,23 @@ You can specify the DB layout using a simple json-file (see also this [example](
 ```json
 {
     "columns": {
-        "InChIKey": {
-            "SD_TAG": ["PUBCHEM_IUPAC_INCHIKEY"],
+        "InChI": {
+            "SD_TAG": ["PUBCHEM_IUPAC_INCHI"],
             "DTYPE": "varchar",
             "NOT_NULL": true,
             "PRIMARY_KEY": true
         },
-        "InChI": {
-            "SD_TAG": ["PUBCHEM_IUPAC_INCHI"],
+        "InChIKey": {
+            "SD_TAG": ["PUBCHEM_IUPAC_INCHIKEY"],
             "DTYPE": "varchar",
             "NOT_NULL": true
         },
+        "InChIKey_1": {
+            "SD_TAG": ["PUBCHEM_IUPAC_INCHIKEY"],
+            "DTYPE": "varchar",
+            "NOT_NULL": true,
+            "CREATE_LIKE": "lambda __x: __x.split('-')[0]"
+        },     
         "xlogp3": {
             "SD_TAG": ["PUBCHEM_XLOGP3", "PUBCHEM_XLOGP3_AA"],
             "DTYPE": "real",
@@ -54,20 +60,21 @@ You can specify the DB layout using a simple json-file (see also this [example](
         "cid": {
             "SD_TAG": ["PUBCHEM_COMPOUND_CID"],
             "DTYPE": "integer",
-            "NOT_NULL": true,
+            "NOT_NULL": true
         }
     }
 }
 ```
 The json-file contains consists of nested dictionaries. The one containing the DB layout is accessed via ```columns```. This dictionary contains a key for each column name in the [*compounds* table](https://github.com/bachi55/local_pubchem_db/blob/bd339a19ffd8b442eda54f0b8684270eabf4c357/pubchem2sqlite/utils.py#L162) and its properites:
 
-| Key | Description |
-| --- | --- |
-| [SD_TAG](https://ftp.ncbi.nlm.nih.gov/pubchem/specifications/pubchem_sdtags.pdf) | List of SD-Tags correponding to the column. For example ```[PUBCHEM_IUPAC_INCHI]``` refering to the InChI of a compound, or, ```["PUBCHEM_XLOGP3", "PUBCHEM_XLOGP3_AA"]``` to its predicted XLogP3 value (here more than one tag can occure in the sdf-files). | 
-| [DTYPE](https://github.com/bachi55/local_pubchem_db/blob/bd339a19ffd8b442eda54f0b8684270eabf4c357/pubchem2sqlite/utils.py#L9) | Type of the information behind the sd-tag. Must be a valid SQLite type. |
-| NOT_NULL | If true, the column cannot contain null entries. If a compound does not have the requested property and the corresponding column should not be null, *it will not be added* to tha DB. | 
-| PRIMARY_KEY | If true, the column is used as primary key for the *compounds* table. Currently, only one column can be specified as primary key. | 
-| WITH_INDEX | If true, an index is created for the column. This allows faster queries with constraints on this column. | 
+| Key | Description | Optional |
+| --- | --- | --- | 
+| [SD_TAG](https://ftp.ncbi.nlm.nih.gov/pubchem/specifications/pubchem_sdtags.pdf) | List of SD-Tags correponding to the column. For example ```[PUBCHEM_IUPAC_INCHI]``` refering to the InChI of a compound, or, ```["PUBCHEM_XLOGP3", "PUBCHEM_XLOGP3_AA"]``` to its predicted XLogP3 value (here more than one tag can occure in the sdf-files). | No | 
+| [DTYPE](https://github.com/bachi55/local_pubchem_db/blob/bd339a19ffd8b442eda54f0b8684270eabf4c357/pubchem2sqlite/utils.py#L9) | Type of the information behind the sd-tag. Must be a valid SQLite type. | No |
+| NOT_NULL | If true, the column cannot contain null entries. If a compound does not have the requested property and the corresponding column should not be null, *it will not be added* to tha DB. | Yes |
+| PRIMARY_KEY | If true, the column is used as primary key for the *compounds* table. Currently, only one column can be specified as primary key. | Yes |
+| WITH_INDEX | If true, an index is created for the column. This allows faster queries with constraints on this column. | Yes |
+| CREATE_LIKE | Value of the SD_TAG can be transformed using a Python lambda function defined as string. For example ```"lambda __x: __x.split('-')[0]"``` applied to the InChIKey tag can be used to only return the first InChIKey part. The lambda function is applied after the value has been converted into the target DTYPE. | Yes |
 
 ### (3) Build the Database
 
@@ -88,7 +95,7 @@ SQLITE_TMPDIR=/my/large/disk/temp python /path/to/local_pubchem_db/build_pubchem
 ## Version History
 
 #### 0.3:
-- Add support for data-transformations of SDFTags
+- Add support for data-transformations of SD_TAG values using lambda functions
 
 #### 0.2:
 - Add flexibility for the DB-layout using a json-file

--- a/default_db_layout.json
+++ b/default_db_layout.json
@@ -17,6 +17,13 @@
             "NOT_NULL": true,
             "WITH_INDEX": true
         },
+        "InChIKey_1": {
+            "SD_TAG": ["PUBCHEM_IUPAC_INCHIKEY"],
+            "CREATE_LIKE": "lambda: __x: __x.split('-')[0]",
+            "DTYPE": "varchar",
+            "NOT_NULL": true,
+            "WITH_INDEX": true
+        },
         "SMILES_CAN": {
             "SD_TAG": ["PUBCHEM_OPENEYE_CAN_SMILES"],
             "DTYPE": "varchar",

--- a/pubchem2sqlite/tests/unittests_utils.py
+++ b/pubchem2sqlite/tests/unittests_utils.py
@@ -276,6 +276,63 @@ class TestDataImport(unittest.TestCase):
         self.assertNotIn(31040, cids)
         self.assertNotIn(46774, cids)
 
+    def test_db_import_with_data_transformation(self):
+        specs = {
+            "columns": {
+                "cid": {
+                    "SD_TAG": ["PUBCHEM_COMPOUND_CID"],
+                    "DTYPE": "integer",
+                    "NOT_NULL": True,
+                    "PRIMARY_KEY": True
+                },
+                "inchikey": {
+                    "SD_TAG": ["PUBCHEM_IUPAC_INCHIKEY"],
+                    "DTYPE": "varchar",
+                    "NOT_NULL": True
+                },
+                "InChI": {
+                    "SD_TAG": ["PUBCHEM_IUPAC_INCHI"],
+                    "DTYPE": "varchar",
+                    "NOT_NULL": True
+                },
+                "xlogp3": {
+                    "SD_TAG": ["PUBCHEM_XLOGP3", "PUBCHEM_XLOGP3_AA"],
+                    "DTYPE": "real",
+                    "NOT_NULL": False,
+                    "CREATE_LIKE": "lambda __x: __x ** 2"
+                }
+            }
+        }
+        # Check that return value does not indicate any error
+        self.assertEqual(0, build_db(self.base_dir, use_gzip=True, reset=True, db_specs=specs))
+
+        self.conn = sqlite3.connect(self.db_fn)
+        self.assertEqual(8,
+                         self.conn.execute("SELECT count(*) FROM compounds").fetchall()[0][0])
+        self.assertEqual("SISXGVIKZQKGLA-UHFFFAOYSA-N",
+                         self.conn.execute("SELECT inchikey FROM compounds WHERE cid == 34516").fetchall()[0][0])
+        self.assertEqual(6.6 ** 2,
+                         self.conn.execute("SELECT xlogp3 FROM compounds WHERE cid == 31038").fetchall()[0][0])
+        self.assertEqual("InChI=1S/C5H6O5.2Na/c6-3(5(9)10)1-2-4(7)8;;/h1-2H2,(H,7,8)(H,9,10);;/q;2*+1/p-2",
+                         self.conn.execute("SELECT InChI FROM compounds WHERE cid == 31040").fetchall()[0][0])
+
+        ################################################################
+
+        # NOTE: Each compound for which at least one "NOT_NULL" information is None (=NULL) will be not added to the DB.
+
+        specs_not_null_xlogp = specs
+        specs_not_null_xlogp["columns"]["xlogp3"]["NOT_NULL"] = True
+        # Check that return value does not indicate any error
+        self.assertEqual(0, build_db(self.base_dir, use_gzip=True, reset=True, db_specs=specs))
+
+        self.conn = sqlite3.connect(self.db_fn)
+        self.assertEqual(5,
+                         self.conn.execute("SELECT count(*) FROM compounds").fetchall()[0][0])
+        cids = [r[0] for r in self.conn.execute("SELECT cid FROM compounds")]
+        self.assertNotIn(34516, cids)
+        self.assertNotIn(31040, cids)
+        self.assertNotIn(46774, cids)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="pubchem2sqlite",
-    version="0.2.0",
+    version="0.3.0",
     license="MIT",
     packages=find_packages(exclude=["tests"]),
 


### PR DESCRIPTION
The use now can specify lambda-functions that are used to transform SD_TAG information, e.g. to extract inchikey level one strings. 